### PR TITLE
Add n2n tests dir and update monorepo docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Este monorepo contiene la plataforma base para **construcción dinámica de sist
 - `/back`: Backend en NestJS, responsable de orquestar la generación de componentes, gestionar la lógica de negocio y exponer APIs.
 - `/orchestrator`: Servicio encargado de interpretar instrucciones del usuario, activar agentes inteligentes, generar código y configurar dependencias.
 - `/infra`: Definición de infraestructura como código (Terraform, CDKTF, Docker) para entornos de desarrollo, pruebas y producción.
+- `/tests/n2n`: Breve descripción de las pruebas de extremo a extremo.
 
 ## 🧩 Características clave
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Este monorepo contiene la plataforma base para **construcción dinámica de sist
 - `/back`: Backend en NestJS, responsable de orquestar la generación de componentes, gestionar la lógica de negocio y exponer APIs.
 - `/orchestrator`: Servicio encargado de interpretar instrucciones del usuario, activar agentes inteligentes, generar código y configurar dependencias.
 - `/infra`: Definición de infraestructura como código (Terraform, CDKTF, Docker) para entornos de desarrollo, pruebas y producción.
-- `/tests/n2n`: Breve descripción de las pruebas de extremo a extremo.
+- `/tests/n2n`: Pruebas de extremo a extremo automatizadas con **Playwright**.
 
 ## 🧩 Características clave
 

--- a/tests/n2n/README.md
+++ b/tests/n2n/README.md
@@ -1,1 +1,5 @@
-# N2N Tests\n\nPlaceholder for end-to-end tests.
+# N2N Tests
+
+Estas pruebas de extremo a extremo se implementan con **Playwright**.
+El objetivo es automatizar escenarios completos de la plataforma y
+validar que cada módulo se integre correctamente.

--- a/tests/n2n/README.md
+++ b/tests/n2n/README.md
@@ -1,0 +1,1 @@
+# N2N Tests\n\nPlaceholder for end-to-end tests.


### PR DESCRIPTION
## Summary
- create `/tests/n2n` directory with placeholder README
- document the new directory in the monorepo structure

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841ec6bc22883328caaf254301a60a3